### PR TITLE
Correct misspelling of MS_DESKTOP compiler define(s)

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1573,7 +1573,7 @@ init_timezone(PyObject *m)
      */
 #ifdef HAVE_DECL_TZNAME
     PyObject *otz0, *otz1;
-#ifdef MS_DEKSTOP
+#ifdef MS_DESKTOP
     tzset();
 #endif
     PyModule_AddIntConstant(m, "timezone", _Py_timezone);

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -85,7 +85,7 @@ WIN32 is still required for the locale module.
 #		define MS_DESKTOP
 #		undef MS_APP
 #	else
-#		undef MS_DEKSTOP
+#		undef MS_DESKTOP
 #		define MS_APP
 #	endif
 #endif

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -137,7 +137,7 @@ PyHKEY_ternaryFailureFunc(PyObject *ob1, PyObject *ob2, PyObject *ob3)
 static void
 PyHKEY_deallocFunc(PyObject *ob)
 {
-#ifdef MS_DEKSTOP
+#ifdef MS_DESKTOP
     /* Can not call PyHKEY_Close, as the ob->tp_type
        has already been cleared, thus causing the type
        check to fail!


### PR DESCRIPTION
While trying to determine a better root cause for Kodi Issue 18846 (https://github.com/xbmc/xbmc/issues/18846), I noted that the MS_DESKTOP macro was misspelled in a few places.

I was unable to build Kodi Python from source for UWP either before or after this change, but the typo seems legitimate and had no detected problems for the Win32 builds.

Will cross-post an update for Issue 18846 (https://github.com/xbmc/xbmc/issues/18846) to this effect.

Thank you very much for the time and effort that has gone into this project, and I hope that this trivial PR ultimately adds some value or resolves some problem(s) for you!

